### PR TITLE
Fix Mongo caching and add sign-in links

### DIFF
--- a/components/projects-page.tsx
+++ b/components/projects-page.tsx
@@ -1,7 +1,8 @@
 "use client"
 
 import { useState, useEffect } from "react"
-import { useSession } from "next-auth/react"
+import { useSession, signOut } from "next-auth/react"
+import { useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import { Grid3X3, Plus, FolderOpen, Clock, Star, Loader2 } from "lucide-react"
@@ -13,6 +14,7 @@ interface ProjectsPageProps {
 
 export function ProjectsPage({ onPageChange, onNewProject }: ProjectsPageProps) {
   const { data: session } = useSession()
+  const router = useRouter()
   const [projects, setProjects] = useState<any[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -119,13 +121,32 @@ export function ProjectsPage({ onPageChange, onNewProject }: ProjectsPageProps) 
               <Button variant="ghost" className="text-slate-300 hover:text-white">
                 Gallery
               </Button>
-            </nav>
-          </div>
+          </nav>
+         </div>
 
-          <Button onClick={onNewProject} className="bg-green-600 hover:bg-green-700">
-            <Plus className="w-4 h-4 mr-2" />
-            New Project
-          </Button>
+          <div className="flex items-center gap-3">
+            {session?.user ? (
+              <Button
+                variant="ghost"
+                className="text-slate-300 hover:text-white"
+                onClick={() => signOut()}
+              >
+                Sign Out
+              </Button>
+            ) : (
+              <Button
+                variant="ghost"
+                className="text-slate-300 hover:text-white"
+                onClick={() => router.push("/auth/signin")}
+              >
+                Sign In
+              </Button>
+            )}
+            <Button onClick={onNewProject} className="bg-green-600 hover:bg-green-700">
+              <Plus className="w-4 h-4 mr-2" />
+              New Project
+            </Button>
+          </div>
         </div>
       </header>
 

--- a/components/sprite-editor.tsx
+++ b/components/sprite-editor.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useEffect, useCallback } from "react"
 import { Button } from "@/components/ui/button"
-import { useSession } from "next-auth/react"
+import { useSession, signOut } from "next-auth/react"
+import { useRouter } from "next/navigation"
 import {
   Download,
   Upload,
@@ -41,6 +42,7 @@ interface SpriteEditorProps {
 
 export function SpriteEditor({ project, onNewProject, onPageChange }: SpriteEditorProps) {
   const { data: session } = useSession()
+  const router = useRouter()
   const [selectedTool, setSelectedTool] = useState("pencil")
   const [zoom, setZoom] = useState(1)
   const [canvasSize] = useState({
@@ -394,6 +396,23 @@ export function SpriteEditor({ project, onNewProject, onPageChange }: SpriteEdit
           </div>
 
           <div className="flex items-center gap-3">
+            {session?.user ? (
+              <Button
+                variant="ghost"
+                className="text-slate-300 hover:text-white"
+                onClick={() => signOut()}
+              >
+                Sign Out
+              </Button>
+            ) : (
+              <Button
+                variant="ghost"
+                className="text-slate-300 hover:text-white"
+                onClick={() => router.push("/auth/signin")}
+              >
+                Sign In
+              </Button>
+            )}
             <Button variant="outline" className="bg-slate-700 border-slate-600 text-white" onClick={handleImport}>
               <Upload className="w-4 h-4 mr-2" />
               Import

--- a/components/sprite-repository-page.tsx
+++ b/components/sprite-repository-page.tsx
@@ -3,6 +3,8 @@
 import { useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
+import { useSession, signOut } from "next-auth/react"
+import { useRouter } from "next/navigation"
 import { Grid3X3, Download, Search, Loader2, ChevronDown, ChevronLeft, ChevronRight } from "lucide-react"
 import { Input } from "@/components/ui/input"
 import { usePokemonPage, usePokemonSearch, gameVersions, type GameVersion } from "@/hooks/use-pokemon-api"
@@ -379,6 +381,8 @@ function Pagination({
 }
 
 export function SpriteRepositoryPage({ onPageChange, onLoadSprite }: SpriteRepositoryPageProps) {
+  const { data: session } = useSession()
+  const router = useRouter()
   const [searchQuery, setSearchQuery] = useState("")
   const [currentPage, setCurrentPage] = useState(1)
   const [selectedGameVersion, setSelectedGameVersion] = useState<GameVersion>(gameVersions[7]) // Default to Black/White
@@ -428,6 +432,25 @@ export function SpriteRepositoryPage({ onPageChange, onLoadSprite }: SpriteRepos
                 Pokemon Repository
               </Button>
             </nav>
+          </div>
+          <div className="flex items-center gap-3">
+            {session?.user ? (
+              <Button
+                variant="ghost"
+                className="text-slate-300 hover:text-white"
+                onClick={() => signOut()}
+              >
+                Sign Out
+              </Button>
+            ) : (
+              <Button
+                variant="ghost"
+                className="text-slate-300 hover:text-white"
+                onClick={() => router.push("/auth/signin")}
+              >
+                Sign In
+              </Button>
+            )}
           </div>
         </div>
       </header>

--- a/lib/mongodb.ts
+++ b/lib/mongodb.ts
@@ -1,6 +1,11 @@
 import mongoose from "mongoose"
 
-const MONGODB_URI = process.env.MONGODB_URI!
+interface MongooseCache {
+  conn: typeof mongoose | null
+  promise: Promise<typeof mongoose> | null
+}
+
+const MONGODB_URI = process.env.MONGODB_URI || ""
 
 if (!MONGODB_URI) {
   throw new Error("Please define the MONGODB_URI environment variable inside .env.local")
@@ -11,7 +16,7 @@ if (!MONGODB_URI) {
  * in development. This prevents connections growing exponentially
  * during API Route usage.
  */
-let cached = global.mongoose
+let cached: MongooseCache = global.mongoose as MongooseCache
 
 if (!cached) {
   cached = global.mongoose = { conn: null, promise: null }

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,6 +1,11 @@
+import mongoose from "mongoose"
+
 declare global {
+  // eslint-disable-next-line no-var
   var mongoose: {
     conn: typeof mongoose | null
     promise: Promise<typeof mongoose> | null
   }
 }
+
+export {}


### PR DESCRIPTION
## Summary
- improve mongo caching types and env fallback
- expose global mongoose types
- add sign in/out buttons to editor and repository pages

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868057ae0cc8333a786bbb160f3b3de