### PR TITLE
Add navigation buttons and handle missing DB config

### DIFF
--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -20,7 +20,10 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Username must be between 3 and 20 characters" }, { status: 400 })
     }
 
-    await connectDB()
+    const db = await connectDB()
+    if (!db) {
+      return NextResponse.json({ error: "Database not configured" }, { status: 500 })
+    }
 
     // Check if user already exists
     const existingUser = await User.findOne({

--- a/components/auth/signin-form.tsx
+++ b/components/auth/signin-form.tsx
@@ -8,7 +8,7 @@ import { useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Card } from "@/components/ui/card"
-import { Grid3X3, Loader2 } from "lucide-react"
+import { Grid3X3, Loader2, X } from "lucide-react"
 
 export function SignInForm() {
   const [email, setEmail] = useState("")
@@ -43,7 +43,15 @@ export function SignInForm() {
   }
 
   return (
-    <div className="min-h-screen bg-slate-900 flex items-center justify-center p-4">
+    <div className="relative min-h-screen bg-slate-900 flex items-center justify-center p-4">
+      <Button
+        size="icon"
+        variant="ghost"
+        className="absolute top-4 left-4 text-white"
+        onClick={() => router.push("/")}
+      >
+        <X className="w-5 h-5" />
+      </Button>
       <Card className="w-full max-w-md p-8 bg-slate-800 border-slate-600">
         <div className="text-center mb-8">
           <div className="flex items-center justify-center gap-2 mb-4">

--- a/components/auth/signup-form.tsx
+++ b/components/auth/signup-form.tsx
@@ -7,7 +7,7 @@ import { useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Card } from "@/components/ui/card"
-import { Grid3X3, Loader2 } from "lucide-react"
+import { Grid3X3, Loader2, X } from "lucide-react"
 
 export function SignUpForm() {
   const [email, setEmail] = useState("")
@@ -63,7 +63,15 @@ export function SignUpForm() {
   }
 
   return (
-    <div className="min-h-screen bg-slate-900 flex items-center justify-center p-4">
+    <div className="relative min-h-screen bg-slate-900 flex items-center justify-center p-4">
+      <Button
+        size="icon"
+        variant="ghost"
+        className="absolute top-4 left-4 text-white"
+        onClick={() => router.push("/")}
+      >
+        <X className="w-5 h-5" />
+      </Button>
       <Card className="w-full max-w-md p-8 bg-slate-800 border-slate-600">
         <div className="text-center mb-8">
           <div className="flex items-center justify-center gap-2 mb-4">

--- a/components/sprite-editor.tsx
+++ b/components/sprite-editor.tsx
@@ -378,6 +378,13 @@ export function SpriteEditor({ project, onNewProject, onPageChange }: SpriteEdit
               <Button
                 variant="ghost"
                 className="text-slate-300 hover:text-white"
+                onClick={onNewProject}
+              >
+                Menu
+              </Button>
+              <Button
+                variant="ghost"
+                className="text-slate-300 hover:text-white"
                 onClick={() => onPageChange("projects")}
               >
                 Projects

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -21,7 +21,11 @@ export const authOptions: NextAuthOptions = {
         }
 
         try {
-          await connectDB()
+          const db = await connectDB()
+          if (!db) {
+            console.error("Database not configured")
+            return null
+          }
 
           const user = await User.findOne({
             email: credentials.email.toLowerCase(),

--- a/lib/mongodb.ts
+++ b/lib/mongodb.ts
@@ -8,7 +8,9 @@ interface MongooseCache {
 const MONGODB_URI = process.env.MONGODB_URI || ""
 
 if (!MONGODB_URI) {
-  throw new Error("Please define the MONGODB_URI environment variable inside .env.local")
+  console.warn(
+    "MONGODB_URI is not defined. Database features will be disabled."
+  )
 }
 
 /**
@@ -23,6 +25,10 @@ if (!cached) {
 }
 
 async function connectDB() {
+  if (!MONGODB_URI) {
+    return null
+  }
+
   if (cached.conn) {
     return cached.conn
   }


### PR DESCRIPTION
## Summary
- add close buttons on sign-in and sign-up screens
- allow returning to the menu from the editor
- warn instead of throwing when `MONGODB_URI` is missing
- guard DB usage in auth functions

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68680eac4f908333aadcbfa534a69f80