### PR TITLE
Use .env file for configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Example environment variables
+
+# MongoDB Connection String
+MONGODB_URI=mongodb://username:password@host:port/database
+
+# NextAuth configuration
+NEXTAUTH_URL=http://localhost:3000
+NEXTAUTH_SECRET=your-nextauth-secret

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,9 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # env files
+.env
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This project uses MongoDB for storing projects and user accounts. To enable data
 1. Create a MongoDB database using [MongoDB Atlas](https://www.mongodb.com/cloud/atlas) or a local MongoDB server.
 2. Copy the connection URI, for example:
    `mongodb+srv://<user>:<password>@cluster0.mongodb.net/<database>?retryWrites=true&w=majority`
-3. Create a `.env.local` file in the project root and add:
+3. Copy `.env.example` to `.env` in the project root and set your values:
    `MONGODB_URI=your-connection-string`
 4. Restart the development server with `npm run dev`.
 

--- a/scripts/test-connection.js
+++ b/scripts/test-connection.js
@@ -1,5 +1,31 @@
 // Test script to verify MongoDB connection
+const fs = require("fs")
+const path = require("path")
 const mongoose = require("mongoose")
+
+function loadEnv() {
+  const envPath = path.resolve(__dirname, "..", ".env")
+  if (fs.existsSync(envPath)) {
+    const lines = fs.readFileSync(envPath, "utf8").split(/\r?\n/)
+    for (const line of lines) {
+      const match = line.match(/^\s*([\w.-]+)\s*=\s*(.*)\s*$/)
+      if (match) {
+        let [, key, value] = match
+        if (
+          (value.startsWith('"') && value.endsWith('"')) ||
+          (value.startsWith("'") && value.endsWith("'"))
+        ) {
+          value = value.slice(1, -1)
+        }
+        if (!process.env[key]) {
+          process.env[key] = value
+        }
+      }
+    }
+  }
+}
+
+loadEnv()
 
 async function testConnection() {
   try {


### PR DESCRIPTION
## Summary
- document using `.env` instead of `.env.local`
- provide `.env.example` template
- update test connection script to load `.env`
- tweak `.gitignore` to keep `.env.example`

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6868294c0f148333b9b549bbbd894f93