### PR TITLE
Add editable battle sprite canvas

### DIFF
--- a/components/sprite-editor.tsx
+++ b/components/sprite-editor.tsx
@@ -663,8 +663,6 @@ export function SpriteEditor({ project, onNewProject, onPageChange }: SpriteEdit
               <BattleSpriteTabs
                 frameData={frameData}
                 pokemonData={project?.pokemonData}
-                gameVersion={project?.gameVersion}
-                onLoadSprite={handleLoadBattleSprite}
               />
             </div>
           )}


### PR DESCRIPTION
## Summary
- make battle sprite cards interactive
- allow drawing pixels with a color picker
- remove preview-only behaviour and unused props

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686830d1890c8333ac206764f7689957