### PR TITLE
Load all sprite types

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,8 +20,23 @@ export default function Home() {
   }
 
   const handleLoadSprite = (spriteData: any) => {
-    // Handle animated sprites with frame extraction
-    if (spriteData.isAnimated) {
+    if (spriteData.spriteSet) {
+      const projectData = {
+        name: spriteData.name,
+        template: {
+          id: spriteData.id,
+          name: spriteData.name,
+          description: spriteData.description,
+          dimensions: { width: spriteData.canvasWidth, height: spriteData.canvasHeight },
+        },
+        dimensions: { width: spriteData.canvasWidth, height: spriteData.canvasHeight },
+        spriteSet: spriteData.spriteSet,
+        spriteType: spriteData.spriteType,
+        pokemonData: spriteData.pokemonData,
+        gameVersion: spriteData.gameVersion,
+      }
+      setCurrentProject(projectData)
+    } else if (spriteData.isAnimated) {
       const projectData = {
         name: spriteData.name,
         template: {

--- a/components/sprite-editor.tsx
+++ b/components/sprite-editor.tsx
@@ -71,6 +71,15 @@ export function SpriteEditor({ project, onNewProject, onPageChange }: SpriteEdit
       backShiny: createEmptyFrames(),
     }
 
+    if (project?.spriteSet) {
+      return {
+        front: project.spriteSet.front || createEmptyFrames(),
+        back: project.spriteSet.back || createEmptyFrames(),
+        frontShiny: project.spriteSet.frontShiny || createEmptyFrames(),
+        backShiny: project.spriteSet.backShiny || createEmptyFrames(),
+      }
+    }
+
     if (project?.isAnimated && project?.animatedFrames) {
       blank.front = project.animatedFrames
       return blank
@@ -103,7 +112,11 @@ export function SpriteEditor({ project, onNewProject, onPageChange }: SpriteEdit
 
   // Load stencil data when project changes
   useEffect(() => {
-    if (project?.stencilData?.pixels || project?.animatedFrames) {
+    if (
+      project?.stencilData?.pixels ||
+      project?.animatedFrames ||
+      project?.spriteSet
+    ) {
       resetSpriteSet(getInitialSpriteSet())
       setCurrentSpriteType((project?.spriteType as SpriteTypeKey) || "front")
     }


### PR DESCRIPTION
## Summary
- load all four battle sprites at once when importing from the repo
- allow `SpriteEditor` to initialize from a `spriteSet`
- handle full sprite sets when opening from the repository

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6868615f045c8333922ad5f950022d17