### PR TITLE
Fix slider infinite update loop

### DIFF
--- a/components/ui/slider.tsx
+++ b/components/ui/slider.tsx
@@ -1,28 +1,32 @@
 "use client"
 
 import * as React from "react"
-import * as SliderPrimitive from "@radix-ui/react-slider"
 
 import { cn } from "@/lib/utils"
 
-const Slider = React.forwardRef<
-  React.ElementRef<typeof SliderPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
->(({ className, ...props }, ref) => (
-  <SliderPrimitive.Root
-    ref={ref}
-    className={cn(
-      "relative flex w-full touch-none select-none items-center",
-      className
-    )}
-    {...props}
-  >
-    <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-secondary">
-      <SliderPrimitive.Range className="absolute h-full bg-primary" />
-    </SliderPrimitive.Track>
-    <SliderPrimitive.Thumb className="block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50" />
-  </SliderPrimitive.Root>
-))
-Slider.displayName = SliderPrimitive.Root.displayName
+export interface SliderProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "onChange" | "value"> {
+  value: number[]
+  onValueChange?: (value: number[]) => void
+}
+
+const Slider = React.forwardRef<HTMLInputElement, SliderProps>(
+  ({ className, value, onValueChange, min, max, step, ...props }, ref) => {
+    return (
+      <input
+        type="range"
+        ref={ref}
+        className={cn("w-full cursor-pointer", className)}
+        min={min}
+        max={max}
+        step={step}
+        value={value[0]}
+        onChange={(e) => onValueChange?.([parseFloat(e.target.value)])}
+        {...props}
+      />
+    )
+  },
+)
+Slider.displayName = "Slider"
 
 export { Slider }


### PR DESCRIPTION
## Summary
- remove Radix slider usage
- add simple range input slider to avoid an infinite update loop

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68687ecfeb348333b3bd01cfc462f861