### PR TITLE
Implement sprite load modal

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,7 +20,25 @@ export default function Home() {
   }
 
   const handleLoadSprite = (spriteData: any) => {
-    if (spriteData.spriteSet) {
+    if (spriteData.targets && currentProject?.spriteSet) {
+      const newSet = {
+        front: { ...currentProject.spriteSet.front },
+        back: { ...currentProject.spriteSet.back },
+        frontShiny: { ...currentProject.spriteSet.frontShiny },
+        backShiny: { ...currentProject.spriteSet.backShiny },
+      }
+
+      ;(Object.keys(spriteData.targets) as Array<keyof typeof newSet>).forEach((type) => {
+        const frames: number[] = spriteData.targets[type]
+        if (!frames || frames.length === 0) return
+        const pixels = spriteData.spriteSet[type][0] || []
+        frames.forEach((f: number) => {
+          newSet[type][f] = pixels
+        })
+      })
+
+      setCurrentProject({ ...currentProject, spriteSet: newSet })
+    } else if (spriteData.spriteSet) {
       const projectData = {
         name: spriteData.name,
         template: {

--- a/components/load-sprite-modal.tsx
+++ b/components/load-sprite-modal.tsx
@@ -1,0 +1,116 @@
+"use client"
+
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import type { SpriteTypeKey } from "@/types/sprite-set"
+
+interface LoadSpriteModalProps {
+  isOpen: boolean
+  availableTypes: Partial<Record<SpriteTypeKey, boolean>>
+  onCancel: () => void
+  onConfirm: (selectedTypes: SpriteTypeKey[], selectedFrames: number[]) => void
+}
+
+export function LoadSpriteModal({
+  isOpen,
+  availableTypes,
+  onCancel,
+  onConfirm,
+}: LoadSpriteModalProps) {
+  const [types, setTypes] = useState<Record<SpriteTypeKey, boolean>>({
+    front: false,
+    back: false,
+    frontShiny: false,
+    backShiny: false,
+  })
+
+  const [frames, setFrames] = useState<Record<number, boolean>>({
+    0: false,
+    1: false,
+    2: false,
+    3: false,
+  })
+
+  const toggleType = (type: SpriteTypeKey) => {
+    setTypes((prev) => ({ ...prev, [type]: !prev[type] }))
+  }
+
+  const toggleFrame = (frame: number) => {
+    setFrames((prev) => ({ ...prev, [frame]: !prev[frame] }))
+  }
+
+  const selectedTypes = Object.entries(types)
+    .filter(([t, v]) => v && availableTypes[t as SpriteTypeKey])
+    .map(([t]) => t as SpriteTypeKey)
+
+  const selectedFrames = Object.entries(frames)
+    .filter(([_, v]) => v)
+    .map(([f]) => Number(f))
+
+  const confirmDisabled = selectedTypes.length === 0 || selectedFrames.length === 0
+
+  if (!isOpen) return null
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-slate-800 rounded-lg p-6 border border-slate-600 w-full max-w-md mx-4">
+        <h3 className="text-white font-medium mb-4">Load Sprite</h3>
+        <div className="space-y-6">
+          <div>
+            <label className="text-sm text-slate-400 block mb-2">Sprite Types</label>
+            <div className="space-y-2">
+              {(Object.keys(types) as SpriteTypeKey[]).map((key) => (
+                <div key={key} className="flex items-center space-x-2">
+                  <Checkbox
+                    id={key}
+                    checked={types[key]}
+                    disabled={!availableTypes[key]}
+                    onCheckedChange={() => toggleType(key)}
+                  />
+                  <label htmlFor={key} className="text-white text-sm capitalize">
+                    {key === "front" && "Front"}
+                    {key === "back" && "Back"}
+                    {key === "frontShiny" && "Shiny Front"}
+                    {key === "backShiny" && "Shiny Back"}
+                  </label>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <label className="text-sm text-slate-400 block mb-2">Frames</label>
+            <div className="grid grid-cols-2 gap-2">
+              {[0, 1, 2, 3].map((f) => (
+                <div key={f} className="flex items-center space-x-2">
+                  <Checkbox
+                    id={`frame${f}`}
+                    checked={frames[f]}
+                    onCheckedChange={() => toggleFrame(f)}
+                  />
+                  <label htmlFor={`frame${f}`} className="text-white text-sm">
+                    Frame {f + 1}
+                  </label>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="flex gap-2 pt-2">
+            <Button variant="outline" onClick={onCancel} className="flex-1 bg-slate-700 border-slate-600 text-white">
+              Cancel
+            </Button>
+            <Button
+              onClick={() => onConfirm(selectedTypes, selectedFrames)}
+              disabled={confirmDisabled}
+              className="flex-1 bg-green-600 hover:bg-green-700"
+            >
+              Confirm
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add modal component to select sprite types and frames
- allow Pokemon cards to open modal to load sprites
- support merging loaded sprites into the current project

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx tsc --noEmit` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6868c2fb8a608333a403f7b2973a071d