### PR TITLE
Implement project save modal and unsaved warnings

### DIFF
--- a/components/login-required-modal.tsx
+++ b/components/login-required-modal.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+
+interface LoginRequiredModalProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+export function LoginRequiredModal({ isOpen, onClose }: LoginRequiredModalProps) {
+  if (!isOpen) return null
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-slate-800 rounded-lg p-6 border border-slate-600 w-full max-w-sm mx-4 text-center space-y-4">
+        <h3 className="text-white font-medium">Sign In Required</h3>
+        <p className="text-slate-400 text-sm">You need to be logged in to save your project.</p>
+        <div className="flex gap-2 pt-2 justify-center">
+          <Button variant="outline" onClick={onClose} className="bg-slate-700 border-slate-600 text-white">
+            Cancel
+          </Button>
+          <Button onClick={() => (window.location.href = "/auth/signin")} className="bg-cyan-600 hover:bg-cyan-700">
+            Sign In
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/save-project-modal.tsx
+++ b/components/save-project-modal.tsx
@@ -1,0 +1,86 @@
+"use client"
+
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Checkbox } from "@/components/ui/checkbox"
+
+interface SaveProjectModalProps {
+  isOpen: boolean
+  defaultName: string
+  defaultTags?: string[]
+  onCancel: () => void
+  onSave: (name: string, tags: string[]) => void
+}
+
+const tagOptions = [
+  "overworld",
+  "battle",
+  "gen1",
+  "gen2",
+  "gen3",
+  "gen4",
+  "gen5",
+]
+
+export function SaveProjectModal({
+  isOpen,
+  defaultName,
+  defaultTags = [],
+  onCancel,
+  onSave,
+}: SaveProjectModalProps) {
+  const [name, setName] = useState(defaultName)
+  const [tags, setTags] = useState<string[]>(defaultTags)
+
+  const toggleTag = (tag: string) => {
+    setTags((t) =>
+      t.includes(tag) ? t.filter((x) => x !== tag) : [...t, tag],
+    )
+  }
+
+  if (!isOpen) return null
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-slate-800 rounded-lg p-6 border border-slate-600 w-full max-w-md mx-4">
+        <h3 className="text-white font-medium mb-4">Save Project</h3>
+        <div className="space-y-6">
+          <div>
+            <label className="text-sm text-slate-400 block mb-2">Project Name</label>
+            <Input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="bg-slate-700 border-slate-600 text-white"
+            />
+          </div>
+          <div>
+            <label className="text-sm text-slate-400 block mb-2">Tags</label>
+            <div className="grid grid-cols-2 gap-2">
+              {tagOptions.map((tag) => (
+                <div key={tag} className="flex items-center space-x-2">
+                  <Checkbox
+                    id={tag}
+                    checked={tags.includes(tag)}
+                    onCheckedChange={() => toggleTag(tag)}
+                  />
+                  <label htmlFor={tag} className="text-white text-sm capitalize">
+                    {tag}
+                  </label>
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="flex gap-2 pt-2">
+            <Button variant="outline" onClick={onCancel} className="flex-1 bg-slate-700 border-slate-600 text-white">
+              Cancel
+            </Button>
+            <Button onClick={() => onSave(name, tags)} className="flex-1 bg-green-600 hover:bg-green-700">
+              Save
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/unsaved-changes-modal.tsx
+++ b/components/unsaved-changes-modal.tsx
@@ -1,0 +1,34 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+
+interface UnsavedChangesModalProps {
+  isOpen: boolean
+  onCancel: () => void
+  onSave: () => void
+  onDiscard: () => void
+}
+
+export function UnsavedChangesModal({ isOpen, onCancel, onSave, onDiscard }: UnsavedChangesModalProps) {
+  if (!isOpen) return null
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-slate-800 rounded-lg p-6 border border-slate-600 w-full max-w-sm mx-4">
+        <h3 className="text-white font-medium mb-2">Unsaved Changes</h3>
+        <p className="text-slate-400 text-sm mb-4">You have unsaved work. Would you like to save before continuing?</p>
+        <div className="flex gap-2 justify-end">
+          <Button variant="outline" onClick={onCancel} className="bg-slate-700 border-slate-600 text-white">
+            Cancel
+          </Button>
+          <Button variant="ghost" onClick={onDiscard} className="text-slate-300 hover:text-white">
+            Discard
+          </Button>
+          <Button onClick={onSave} className="bg-green-600 hover:bg-green-700">
+            Save
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add `SaveProjectModal` for naming and tagging before saving
- add login required and unsaved changes modals
- track unsaved changes in `SpriteEditor`
- prompt to save when navigating or starting a new project
- integrate modal flow with cloud save

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868c9910a74833396e92a09e15316df