### PR TITLE
Add save button to sprite editor header

### DIFF
--- a/components/sprite-editor.tsx
+++ b/components/sprite-editor.tsx
@@ -656,6 +656,10 @@ export function SpriteEditor({ project, onNewProject, onPageChange }: SpriteEdit
               <Upload className="w-4 h-4 mr-2" />
               Import
             </Button>
+            <Button className="bg-purple-600 hover:bg-purple-700" onClick={handleSave}>
+              <SaveIcon className="w-4 h-4 mr-2" />
+              Save
+            </Button>
             <Button className="bg-green-600 hover:bg-green-700" onClick={() => setShowExportModal(true)}>
               <Download className="w-4 h-4 mr-2" />
               Export


### PR DESCRIPTION
## Summary
- add a Save button in the editor header that triggers existing download functionality

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868cd63574c83339c47098035b2127d