### PR TITLE
Fix infinite loop in sprite store update

### DIFF
--- a/contexts/sprite-store.tsx
+++ b/contexts/sprite-store.tsx
@@ -38,29 +38,29 @@ const SpriteStoreContext = createContext<SpriteStoreContextValue | undefined>(un
 export function SpriteStoreProvider({ children }: { children: React.ReactNode }) {
   const [store, setStore] = useState<SpriteStore>(defaultStore)
 
-  const setCurrentSpriteType = (type: SpriteTypeKey) => {
+  const setCurrentSpriteType = React.useCallback((type: SpriteTypeKey) => {
     setStore((s) => ({ ...s, currentSpriteType: type }))
-  }
+  }, [])
 
-  const setCurrentFrame = (frame: number) => {
+  const setCurrentFrame = React.useCallback((frame: number) => {
     setStore((s) => ({ ...s, currentFrame: frame }))
-  }
+  }, [])
 
-  const setZoom = (z: number) => {
+  const setZoom = React.useCallback((z: number) => {
     setStore((s) => ({ ...s, zoom: z }))
-  }
+  }, [])
 
-  const updateFrame = (pixels: Pixel[]) => {
+  const updateFrame = React.useCallback((pixels: Pixel[]) => {
     setStore((s) => {
       const frameData = s[s.currentSpriteType]
       const updated: FrameData = { ...frameData, [s.currentFrame]: pixels }
       return { ...s, [s.currentSpriteType]: updated }
     })
-  }
+  }, [])
 
-  const replaceStore = (newStore: SpriteStore) => {
+  const replaceStore = React.useCallback((newStore: SpriteStore) => {
     setStore(newStore)
-  }
+  }, [])
 
   return (
     <SpriteStoreContext.Provider


### PR DESCRIPTION
## Summary
- memoize sprite store update helpers to prevent new function refs on each render

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868cda0abac8333b9d8a9a09cd90215