### PR TITLE
Revamp save flow with modal preview

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -94,6 +94,25 @@ export default function Home() {
     setCurrentPage("studio")
   }
 
+  const handleProjectSelect = async (id: string) => {
+    try {
+      const res = await fetch(`/api/projects/${id}`)
+      if (!res.ok) throw new Error('Failed to load project')
+      const data = await res.json()
+      const project = data.project
+      if (project.frameData) {
+        setCurrentProject({
+          name: project.name,
+          dimensions: { width: project.canvasWidth, height: project.canvasHeight },
+          spriteSet: project.frameData,
+          tags: project.tags,
+        })
+        setCurrentPage('studio')
+      }
+    } catch (e) {
+      console.error(e)
+    }
+  }
   const handlePageChange = (page: "studio" | "projects" | "stencils") => {
     setCurrentPage(page)
   }
@@ -112,7 +131,13 @@ export default function Home() {
   }
 
   if (currentPage === "projects") {
-    return <ProjectsPage onPageChange={handlePageChange} onNewProject={() => setShowCreateModal(true)} />
+    return (
+      <ProjectsPage
+        onPageChange={handlePageChange}
+        onNewProject={() => setShowCreateModal(true)}
+        onProjectSelect={handleProjectSelect}
+      />
+    )
   }
 
   if (currentPage === "stencils") {

--- a/components/projects-page.tsx
+++ b/components/projects-page.tsx
@@ -10,9 +10,10 @@ import { Grid3X3, Plus, FolderOpen, Clock, Star, Loader2 } from "lucide-react"
 interface ProjectsPageProps {
   onPageChange: (page: "studio" | "projects" | "stencils") => void
   onNewProject: () => void
+  onProjectSelect: (id: string) => void
 }
 
-export function ProjectsPage({ onPageChange, onNewProject }: ProjectsPageProps) {
+export function ProjectsPage({ onPageChange, onNewProject, onProjectSelect }: ProjectsPageProps) {
   const { data: session } = useSession()
   const router = useRouter()
   const [projects, setProjects] = useState<any[]>([])
@@ -190,6 +191,7 @@ export function ProjectsPage({ onPageChange, onNewProject }: ProjectsPageProps) 
                 <Card
                   key={project.id || project._id}
                   className="p-4 bg-slate-800 border-slate-600 hover:border-slate-500 cursor-pointer transition-all"
+                  onClick={() => onProjectSelect(project.id || project._id)}
                 >
                   <div className="space-y-3">
                     <div className="w-full h-16 bg-slate-700 rounded flex items-center justify-center">

--- a/components/sprite-editor.tsx
+++ b/components/sprite-editor.tsx
@@ -656,7 +656,7 @@ export function SpriteEditor({ project, onNewProject, onPageChange }: SpriteEdit
               <Upload className="w-4 h-4 mr-2" />
               Import
             </Button>
-            <Button className="bg-purple-600 hover:bg-purple-700" onClick={handleSave}>
+            <Button className="bg-purple-600 hover:bg-purple-700" onClick={() => setShowSaveModal(true)}>
               <SaveIcon className="w-4 h-4 mr-2" />
               Save
             </Button>
@@ -737,7 +737,7 @@ export function SpriteEditor({ project, onNewProject, onPageChange }: SpriteEdit
                     ) : (
                       <>
                         <Cloud className="w-4 h-4 mr-2" />
-                        Save to Cloud
+                        Save
                       </>
                     )}
                   </Button>
@@ -999,6 +999,9 @@ export function SpriteEditor({ project, onNewProject, onPageChange }: SpriteEdit
         isOpen={showSaveModal}
         defaultName={project?.name || "Untitled Project"}
         defaultTags={project?.tags || []}
+        spriteSet={spriteSet}
+        canvasWidth={canvasSize.width}
+        canvasHeight={canvasSize.height}
         onCancel={() => setShowSaveModal(false)}
         onSave={(n, t) => {
           setShowSaveModal(false)


### PR DESCRIPTION
## Summary
- update save flow so the main Save button opens a modal
- include a preview of loaded sprites when saving
- allow selecting projects from the Projects page
- load selected project into the editor

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686962b4f5ac8333a490fd65500f9af2