### PR TITLE
Fix frame navigator crash when importing images

### DIFF
--- a/components/sprite-editor.tsx
+++ b/components/sprite-editor.tsx
@@ -513,16 +513,23 @@ export function SpriteEditor({ project, onNewProject, onPageChange }: SpriteEdit
 
   const applyPixelsToFrame = useCallback(
     (pixels: Pixel[], spriteType: SpriteTypeKey, frame: number) => {
-      setSpriteSet((prev) => ({
-        ...prev,
-        [spriteType]: { ...prev[spriteType], [frame]: pixels },
-      }))
+      const updatedSpriteType = {
+        ...spriteSet[spriteType],
+        [frame]: pixels,
+      }
+
+      const newSpriteSet = {
+        ...spriteSet,
+        [spriteType]: updatedSpriteType,
+      }
+
+      setSpriteSet(newSpriteSet)
 
       if (spriteType === currentSpriteType && frame === currentFrame) {
         updateFrame(pixels)
       }
     },
-    [setSpriteSet, updateFrame, currentSpriteType, currentFrame],
+    [setSpriteSet, spriteSet, updateFrame, currentSpriteType, currentFrame],
   )
 
   const handleImport = () => {


### PR DESCRIPTION
## Summary
- ensure `setSpriteSet` receives a plain object when importing images so frame data is not lost

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6869915f73048333ac8ff6ccbe2c28f8