### PR TITLE
Fix toast timeout and search effect

### DIFF
--- a/components/ui/use-toast.ts
+++ b/components/ui/use-toast.ts
@@ -9,7 +9,7 @@ import type {
 } from "@/components/ui/toast"
 
 const TOAST_LIMIT = 1
-const TOAST_REMOVE_DELAY = 1000000
+const TOAST_REMOVE_DELAY = 5000
 
 type ToasterToast = ToastProps & {
   id: string
@@ -182,7 +182,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,

--- a/hooks/use-pokemon-api.ts
+++ b/hooks/use-pokemon-api.ts
@@ -254,7 +254,7 @@ export function usePokemonSearch(query: string, gameVersion: GameVersion) {
 
     const debounceTimer = setTimeout(searchPokemon, 800)
     return () => clearTimeout(debounceTimer)
-  }, [query, gameVersion, searchCache])
+  }, [query, gameVersion])
 
   return { results, loading, error }
 }

--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -9,7 +9,7 @@ import type {
 } from "@/components/ui/toast"
 
 const TOAST_LIMIT = 1
-const TOAST_REMOVE_DELAY = 1000000
+const TOAST_REMOVE_DELAY = 5000
 
 type ToasterToast = ToastProps & {
   id: string
@@ -182,7 +182,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- reduce long toast removal delay
- avoid repeated listener registration in toast hooks
- stop refetching pokemon search results when cache updates

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68699c6a60b8833385a3453e932aa2a4