### PR TITLE
Fix project schema to include frames

### DIFF
--- a/models/Project.ts
+++ b/models/Project.ts
@@ -1,9 +1,47 @@
-import mongoose from 'mongoose'
+import mongoose, { Schema, type Document } from "mongoose"
 
-const ProjectSchema = new mongoose.Schema({
-  name: { type: String, required: true },
-  spriteData: { type: Object, required: true },
-  updatedAt: { type: Date, default: Date.now },
-})
+export interface Frame {
+  frameNumber: number
+  pixels: any[]
+}
 
-export default mongoose.models.Project || mongoose.model('Project', ProjectSchema)
+export interface IProject extends Document {
+  userId: mongoose.Types.ObjectId
+  name: string
+  description: string
+  canvasWidth: number
+  canvasHeight: number
+  isAnimated: boolean
+  frames: Frame[]
+  tags: string[]
+  pokemonData: any
+  gameVersion: any
+  createdAt: Date
+  updatedAt: Date
+}
+
+const FrameSchema = new Schema<Frame>(
+  {
+    frameNumber: { type: Number, required: true },
+    pixels: { type: Array, required: true },
+  },
+  { _id: false }
+)
+
+const ProjectSchema = new Schema<IProject>(
+  {
+    userId: { type: Schema.Types.ObjectId, ref: "User", required: true },
+    name: { type: String, required: true },
+    description: { type: String, default: "" },
+    canvasWidth: { type: Number, required: true },
+    canvasHeight: { type: Number, required: true },
+    isAnimated: { type: Boolean, default: false },
+    frames: [FrameSchema],
+    tags: { type: [String], default: [] },
+    pokemonData: { type: Schema.Types.Mixed, default: null },
+    gameVersion: { type: Schema.Types.Mixed, default: null },
+  },
+  { timestamps: true }
+)
+
+export default mongoose.models.Project || mongoose.model<IProject>("Project", ProjectSchema)


### PR DESCRIPTION
## Summary
- update the Project mongoose schema to reflect the current project structure
- drop obsolete `spriteData` field and add frame data and metadata fields

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68699efa191883338b77579813b4d197