### PR TITLE
Fix saving sprite data with projects

### DIFF
--- a/app/api/projects/[id]/route.ts
+++ b/app/api/projects/[id]/route.ts
@@ -35,11 +35,14 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
       })
     }
 
+    const spriteSet = project.spriteSet || null
+
     return NextResponse.json({
       project: {
         ...project,
         id: project._id,
         frameData,
+        spriteSet,
       },
     })
   } catch (error) {
@@ -59,18 +62,19 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
       return NextResponse.json({ error: "Invalid project ID" }, { status: 400 })
     }
 
-    const { name, description, frameData, tags } = await request.json()
+    const { name, description, frameData, spriteSet, tags } = await request.json()
 
     await connectDB()
 
-    // Convert frameData object to frames array
-    const frames = []
-    if (frameData) {
-      for (const [frameNumber, pixels] of Object.entries(frameData)) {
+    // Convert provided data to frames array (for legacy preview usage)
+    const frames: any[] = []
+    const sourceData: any = frameData || (spriteSet ? spriteSet.front : null)
+    if (sourceData) {
+      for (const [frameNumber, pixels] of Object.entries(sourceData)) {
         if (Array.isArray(pixels) && pixels.length > 0) {
           frames.push({
             frameNumber: Number.parseInt(frameNumber),
-            pixels: pixels,
+            pixels,
           })
         }
       }
@@ -82,6 +86,7 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
         name,
         description,
         frames,
+        spriteSet: spriteSet || null,
         tags: tags || [],
         updatedAt: new Date(),
       },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -108,11 +108,15 @@ export default function Home() {
       if (!res.ok) throw new Error('Failed to load project')
       const data = await res.json()
       const project = data.project
-      if (project.frameData) {
+      const spriteSet = project.spriteSet || project.frameData
+      if (spriteSet) {
         setCurrentProject({
           name: project.name,
-          dimensions: { width: project.canvasWidth, height: project.canvasHeight },
-          spriteSet: project.frameData,
+          dimensions: {
+            width: project.canvasWidth,
+            height: project.canvasHeight,
+          },
+          spriteSet,
           tags: project.tags,
         })
         setCurrentPage('studio')

--- a/components/sprite-editor.tsx
+++ b/components/sprite-editor.tsx
@@ -142,12 +142,13 @@ export function SpriteEditor({ project, onNewProject, onPageChange }: SpriteEdit
       backShiny: createEmptyFrames(),
     }
 
-    if (project?.spriteSet) {
+    const set = project?.spriteSet || project?.frameData
+    if (set) {
       return {
-        front: project.spriteSet.front || createEmptyFrames(),
-        back: project.spriteSet.back || createEmptyFrames(),
-        frontShiny: project.spriteSet.frontShiny || createEmptyFrames(),
-        backShiny: project.spriteSet.backShiny || createEmptyFrames(),
+        front: set.front || createEmptyFrames(),
+        back: set.back || createEmptyFrames(),
+        frontShiny: set.frontShiny || createEmptyFrames(),
+        backShiny: set.backShiny || createEmptyFrames(),
       }
     }
 

--- a/models/Project.ts
+++ b/models/Project.ts
@@ -13,6 +13,7 @@ export interface IProject extends Document {
   canvasHeight: number
   isAnimated: boolean
   frames: Frame[]
+  spriteSet: any
   tags: string[]
   pokemonData: any
   gameVersion: any
@@ -37,6 +38,7 @@ const ProjectSchema = new Schema<IProject>(
     canvasHeight: { type: Number, required: true },
     isAnimated: { type: Boolean, default: false },
     frames: [FrameSchema],
+    spriteSet: { type: Schema.Types.Mixed, default: null },
     tags: { type: [String], default: [] },
     pokemonData: { type: Schema.Types.Mixed, default: null },
     gameVersion: { type: Schema.Types.Mixed, default: null },


### PR DESCRIPTION
## Summary
- store spriteSet on the Project model
- accept `spriteSet` when creating/updating projects
- return `spriteSet` from project endpoints
- prefer `spriteSet` when loading projects on the client
- handle spriteSet or frameData when initializing the editor

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6869a105adec8333b547f21bf4939fcf